### PR TITLE
Remove the link to the online demo

### DIFF
--- a/source/application.rst
+++ b/source/application.rst
@@ -4,8 +4,7 @@ Sample Application
 
 The following outlines how a sample application uses the Inrupt's Solid
 React SDK to log in to a user's Pod and displays the Profile. The
-sample application allows users to view/edit user profile. You can play
-with the application at https://react-demo.docs.inrupt.com/.
+sample application allows users to view/edit user profile.
 
 Set Up
 ======


### PR DESCRIPTION
The demo app isn't well-maintained. The source code will need to be updated for the code samples to remain accurate. In the meantime the app is taken offline, so that it isn't as misleading.